### PR TITLE
Fix: first message of stream handler error when stream offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ tasks.json
 quotes.json
 channelPointRedeems.json
 intervalCommands.json
+
+# pnpm files
+*/pnpm-lock.yaml

--- a/server/src/handlers/twitch/irc/firstMessageOfStreamHandler.ts
+++ b/server/src/handlers/twitch/irc/firstMessageOfStreamHandler.ts
@@ -12,6 +12,11 @@ export function firstMessageOfStreamHandler(connection: websocket.connection, pa
     return;
   }
 
+  // If the stream is offline, then we don't handle this event
+  if (StreamState.status === 'offline') {
+    return;
+  }
+
   const nick = parsedMessage.source?.nick;
   const userId = parsedMessage.tags?.['user-id'];
   const displayName = parsedMessage.tags?.['display-name'];


### PR DESCRIPTION
Fixes error when a message is received and the stream is offline

- update gitignore files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to include specific configuration files.

- **Bug Fixes**
  - Enhanced the Twitch IRC handler to prevent processing messages when the stream is offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->