### PR TITLE
7TV Emote Fixes

### DIFF
--- a/server/src/chat/loadEmotes.ts
+++ b/server/src/chat/loadEmotes.ts
@@ -102,8 +102,8 @@ export const removeSevenTVEmote = (emoteId: string) => {
 
 export const addSevenTVEmote = async (emote: SevenTVEmote) => {
   const name = emote.name;
-  // Use the second in the array of files as it will be the smallest WebP
-  const file = emote.data.host.files[2];
+  // Use the largest emote for that 4K crispiness
+  const file = emote.data.host.files.find((file) => file.name === '3x.webp' || file.name === '3x.avif');
 
   if (file) {
     const imageUrl = `${emote.data.host.url}/${file.name}`;

--- a/server/src/handlers/sevenTV/sevenTVWebsocket.ts
+++ b/server/src/handlers/sevenTV/sevenTVWebsocket.ts
@@ -154,10 +154,11 @@ export function runSevenTVWebsocket(seventTVTwitchUser: SevenTVTwitchUser) {
             case SevenTVWebsocketOpCodes.Dispatch: {
               const { body } = d as DispatchMessage['d'];
               // An emote has been added to the user's emote set
-              if ((body.pushed && body.pushed.length) || (body.added && body.added.length)) {
+              if ((body.pushed && body.pushed.length) || (body.added && body.added.length) || (body.updated && body.updated.length)) {
                 const pushed = body.pushed || [];
                 const added = body.added || [];
-                for (const entry of [...pushed, ...added]) {
+                const updated = body.updated || [];
+                for (const entry of [...pushed, ...added, ...updated]) {
                   if (entry.key === 'emotes') {
                     const emote = entry.value as SevenTVEmote;
                     logger.info(`SevenTV WebSocket: Emote added: "${emote.name}" with ID: ${emote.id}`);
@@ -167,10 +168,11 @@ export function runSevenTVWebsocket(seventTVTwitchUser: SevenTVTwitchUser) {
               }
 
               // An emote has been removed from the user's emote set
-              if ((body.removed && body.removed.length) || (body.pulled && body.pulled.length)) {
+              if ((body.removed && body.removed.length) || (body.pulled && body.pulled.length) || (body.updated && body.updated.length)) {
                 const pulled = body.pulled || [];
                 const removed = body.removed || [];
-                for (const entry of [...removed, ...pulled]) {
+                const updated = body.updated || [];
+                for (const entry of [...removed, ...pulled, ...updated]) {
                   if (entry.key === 'emotes') {
                     const emote = entry.old_value as SevenTVEmote;
                     logger.info(`SevenTV WebSocket: Emote removed: "${emote.name}" with ID: ${emote.id}`);


### PR DESCRIPTION
Extended the 7TV websocket support to handle `updated` messages.

An update removes the old emotes from the overlay. This may or may not be desirable.

Tested with the client locally.