### PR TITLE
Fix: follow event subscription now uses version 2

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,7 +10,7 @@ The listed scopes are relevant to the existing commands in the repository. If yo
 
 ### Twitch
 
-The required scopes are `chat:read`, `chat:edit`, `channel:manage:redemptions`, `channel:read:redemptions`, `moderator:manage:banned_users` and `channel:manage:broadcast`.
+The required scopes are `chat:read`, `chat:edit`, `channel:manage:redemptions`, `channel:read:redemptions`, `moderator:manage:banned_users`, `channel:manage:broadcast` and `moderator:read:followers`.
 
 #### Method 1: Automated Retrieval
 

--- a/server/src/handlers/twitch/event-sub/subscribers/eventSubscribe.ts
+++ b/server/src/handlers/twitch/event-sub/subscribers/eventSubscribe.ts
@@ -4,14 +4,14 @@ import { TWITCH_HELIX_URL } from '../../../../constants';
 import { logger } from '../../../../logger';
 import type { EventSubCondition, EventsubSubscriptionType } from '../../../../typings/twitchEvents';
 
-export const eventSubscribe = async (sessionId: string, type: EventsubSubscriptionType, condition: EventSubCondition) => {
+export const eventSubscribe = async (sessionId: string, type: EventsubSubscriptionType, condition: EventSubCondition, version = '1') => {
   try {
     const url = `${TWITCH_HELIX_URL}eventsub/subscriptions`;
     const accessToken = getCurrentAccessToken();
 
     const body = JSON.stringify({
       type,
-      version: '1',
+      version,
       condition,
       transport: {
         method: 'websocket',

--- a/server/src/handlers/twitch/event-sub/subscribers/subscribeToFollows.ts
+++ b/server/src/handlers/twitch/event-sub/subscribers/subscribeToFollows.ts
@@ -6,9 +6,15 @@ import { eventSubscribe } from './eventSubscribe';
 
 export const subscribeToFollows = async (sessionId: string) => {
   try {
-    await eventSubscribe(sessionId, 'channel.follow', {
-      broadcaster_user_id: Config.twitch.broadcaster_id,
-    });
+    await eventSubscribe(
+      sessionId,
+      'channel.follow',
+      {
+        broadcaster_user_id: Config.twitch.broadcaster_id,
+        moderator_user_id: Config.twitch.broadcaster_id,
+      },
+      '2',
+    );
   } catch (error) {
     logger.error(error);
   }


### PR DESCRIPTION
The follow event requires an additional scope `moderator:read:followers` and the moderator_user_id to be sent. We use the same value as the broadcaster ID.