### PR TITLE
Fix: Show an error on forbidden API response for fetching custom rewards

### DIFF
--- a/server/src/handlers/twitch/helix/customRewards.ts
+++ b/server/src/handlers/twitch/helix/customRewards.ts
@@ -44,7 +44,7 @@ type NewCustomReward = {
   should_redemptions_skip_request_queue?: boolean; // A Boolean value that determines whether redemptions should be set to FULFILLED status immediately when a reward is redeemed. If false, status is set to UNFULFILLED and follows the normal request queue process. The default is false.
 };
 
-let customRewards: CustomReward[];
+let customRewards: CustomReward[] = [];
 
 export const getCustomRewards = () => customRewards;
 

--- a/server/src/handlers/twitch/helix/customRewards.ts
+++ b/server/src/handlers/twitch/helix/customRewards.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 // https://api.twitch.tv/helix/channel_points/custom_rewards
 
+import { StatusCodes } from 'http-status-codes';
 import { fetchWithRetry, getCurrentAccessToken } from '../../../auth/twitch';
 import Config from '../../../config';
 import { TWITCH_HELIX_URL } from '../../../constants';
@@ -108,6 +109,12 @@ export const fetchCustomRewards = async (): Promise<void> => {
         Authorization: `Bearer ${accessToken}`,
       },
     });
+
+    if (hasOwnProperty(result, 'status') && result.status === StatusCodes.FORBIDDEN) {
+      logger.error('Unable to retrieve custom rewards. You need to be an affiliate or partner.');
+      return;
+    }
+
     if (hasOwnProperty(result, 'data')) {
       const customRewardsData: unknown = result.data;
       assertArray(customRewardsData);


### PR DESCRIPTION
If you are not an affiliate or partner then the API responds with a forbidden status code which currently crashes the bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for forbidden status codes in custom rewards, ensuring better logging and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->