### PR TITLE
Add !vanish command

### DIFF
--- a/server/src/botCommands.ts
+++ b/server/src/botCommands.ts
@@ -24,6 +24,7 @@ import { songqueue } from './commands/songqueue';
 import { spotlight } from './commands/spotlight';
 import { tts } from './commands/tts';
 import { uptime } from './commands/uptime';
+import { vanish } from './commands/vanish';
 import { viewers } from './commands/viewers';
 import { voices } from './commands/voices';
 import { welcome } from './commands/welcome';
@@ -104,6 +105,7 @@ const builtInCommands: BotCommand[] = [
   spotlight,
   tts,
   uptime,
+  vanish,
   viewers,
   voices,
   welcome,

--- a/server/src/commands/vanish.ts
+++ b/server/src/commands/vanish.ts
@@ -1,5 +1,6 @@
 import { MINUTE_MS } from '../constants';
 import { banUser } from '../handlers/twitch/helix/moderation';
+import { sendChatMessage } from './helpers/sendChatMessage';
 import type { BotCommand } from '../types';
 
 const DURATION_S = 5;
@@ -10,6 +11,13 @@ export const vanish: BotCommand = {
   cooldown: 5 * MINUTE_MS,
   callback: (connection, parsedCommand) => {
     const userId = parsedCommand.parsedMessage.tags?.['user-id'];
+    const isModerator = parsedCommand.parsedMessage.tags?.mod === '1';
+
+    if (isModerator) {
+      sendChatMessage(connection, "I won't timeout a moderator!");
+      return;
+    }
+
     if (userId) {
       void banUser(userId, DURATION_S);
     }

--- a/server/src/commands/vanish.ts
+++ b/server/src/commands/vanish.ts
@@ -2,7 +2,7 @@ import { MINUTE_MS } from '../constants';
 import { banUser } from '../handlers/twitch/helix/moderation';
 import type { BotCommand } from '../types';
 
-const COOLDOWN_S = 5;
+const DURATION_S = 5;
 
 export const vanish: BotCommand = {
   command: ['vanish'],
@@ -11,7 +11,7 @@ export const vanish: BotCommand = {
   callback: (connection, parsedCommand) => {
     const userId = parsedCommand.parsedMessage.tags?.['user-id'];
     if (userId) {
-      void banUser(userId, COOLDOWN_S);
+      void banUser(userId, DURATION_S);
     }
   },
 };

--- a/server/src/commands/vanish.ts
+++ b/server/src/commands/vanish.ts
@@ -1,0 +1,17 @@
+import { MINUTE_MS } from '../constants';
+import { banUser } from '../handlers/twitch/helix/moderation';
+import type { BotCommand } from '../types';
+
+const COOLDOWN_S = 5;
+
+export const vanish: BotCommand = {
+  command: ['vanish'],
+  id: 'vanish',
+  cooldown: 5 * MINUTE_MS,
+  callback: (connection, parsedCommand) => {
+    const userId = parsedCommand.parsedMessage.tags?.['user-id'];
+    if (userId) {
+      void banUser(userId, COOLDOWN_S);
+    }
+  },
+};

--- a/server/src/commands/vanish.ts
+++ b/server/src/commands/vanish.ts
@@ -3,7 +3,7 @@ import { banUser } from '../handlers/twitch/helix/moderation';
 import { sendChatMessage } from './helpers/sendChatMessage';
 import type { BotCommand } from '../types';
 
-const DURATION_S = 5;
+const DURATION_S = 1;
 
 export const vanish: BotCommand = {
   command: ['vanish'],

--- a/server/src/handlers/twitch/helix/moderation.ts
+++ b/server/src/handlers/twitch/helix/moderation.ts
@@ -5,19 +5,17 @@ import Config from '../../../config';
 import { TWITCH_HELIX_URL } from '../../../constants';
 import { logger } from '../../../logger';
 
-export const banUser = async (userId: string, duration?: number) => {
+export const banUser = async (userId: string, duration?: number): Promise<void> => {
   try {
     const url = `${TWITCH_HELIX_URL}moderation/bans?broadcaster_id=${Config.twitch.broadcaster_id}&moderator_id=${Config.twitch.broadcaster_id}`;
     const accessToken = getCurrentAccessToken();
 
-    const request = {
+    const body = JSON.stringify({
       data: {
         user_id: userId,
         ...(duration !== undefined && { duration }),
       },
-    };
-
-    const body = JSON.stringify(request);
+    });
 
     await fetchWithRetry(url, {
       method: 'POST',

--- a/server/src/handlers/twitch/helix/moderation.ts
+++ b/server/src/handlers/twitch/helix/moderation.ts
@@ -5,16 +5,19 @@ import Config from '../../../config';
 import { TWITCH_HELIX_URL } from '../../../constants';
 import { logger } from '../../../logger';
 
-export const banUser = async (userId: string) => {
+export const banUser = async (userId: string, duration?: number) => {
   try {
     const url = `${TWITCH_HELIX_URL}moderation/bans?broadcaster_id=${Config.twitch.broadcaster_id}&moderator_id=${Config.twitch.broadcaster_id}`;
     const accessToken = getCurrentAccessToken();
 
-    const body = JSON.stringify({
+    const request = {
       data: {
         user_id: userId,
+        ...(duration !== undefined && { duration }),
       },
-    });
+    };
+
+    const body = JSON.stringify(request);
 
     await fetchWithRetry(url, {
       method: 'POST',


### PR DESCRIPTION
The !vanish command timeout a user for 5 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `vanish` command for the bot, enabling users to be banned from chat temporarily with a cooldown.
	- Added functionality for temporary bans, allowing moderators to specify a ban duration.

- **Bug Fixes**
	- Ensured the `banUser` function correctly formats requests to include optional ban durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->