### PR TITLE
fix: banUser not awaited

### DIFF
--- a/server/src/commands/vanish.ts
+++ b/server/src/commands/vanish.ts
@@ -9,7 +9,7 @@ export const vanish: BotCommand = {
   command: ['vanish'],
   id: 'vanish',
   cooldown: 5 * MINUTE_MS,
-  callback: (connection, parsedCommand) => {
+  callback: async (connection, parsedCommand) => {
     const userId = parsedCommand.parsedMessage.tags?.['user-id'];
     const isModerator = parsedCommand.parsedMessage.tags?.mod === '1';
 
@@ -19,7 +19,7 @@ export const vanish: BotCommand = {
     }
 
     if (userId) {
-      void banUser(userId, DURATION_S);
+      await banUser(userId, DURATION_S);
     }
   },
 };


### PR DESCRIPTION
Missing await before call to banUser in vanish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `vanish` command to handle user bans asynchronously, improving command execution reliability.
  
- **Bug Fixes**
	- Fixed the issue where the user banning operation would not complete properly before the command execution continued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->