### PR TITLE
Fix: use twitch auth port set in config.twitch.redirect_uri 

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@ The required scopes are `chat:read`, `chat:edit`, `channel:manage:redemptions`, 
 
 #### Method 1: Automated Retrieval
 
-Fill in the required details in `config.json` for Twitch, leaving the `auth_code` field empty. Ensure your `redirect_uri` is set to `http://localhost:3000`.
+Fill in the required details in `config.json` for Twitch, leaving the `auth_code` field empty. We suggest your `redirect_uri` is set to `http://localhost:3000`. The bot will listen on whichever port you specify in the `redirect_uri`.
 
 Once set, run the server with `npm run start` within the server directory. The bot will automatically retrieve and update your `auth_code`.
 

--- a/server/src/auth/twitch.ts
+++ b/server/src/auth/twitch.ts
@@ -173,6 +173,10 @@ export const getTwitchAccessToken = async (twitchConfig: TwitchConfig): Promise<
 
 export const twitchAuthCodeRouter = async () => {
   if (Config.twitch.client_id && !Config.twitch.auth_code) {
+    const port = parseInt(Config.twitch.redirect_uri.split(':')[2]);
+
+    logger.info(`Listening on port ${String(port)} for Twitch auth code`);
+
     express()
       .get('/', (req, res) => {
         if (req.query.code) {
@@ -192,7 +196,7 @@ export const twitchAuthCodeRouter = async () => {
           res.send('Hello from twitch-bot! No Twitch auth code received. You may close this window.');
         }
       })
-      .listen(3000);
+      .listen(port);
 
     logger.info(`Getting Twitch auth code with scopes ${pc.green(`${Config.twitch.scopes.join(', ')}`)}`);
     await getTwitchAuthCode();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation for configuring Twitch, clarifying the flexibility of the `redirect_uri` and allowing users to choose different ports.
	- Enhanced server configuration to dynamically set the listening port based on the `redirect_uri`, improving adaptability for users.
  
- **Bug Fixes**
	- Added logging to indicate the port for the Twitch authentication server, aiding in troubleshooting and user awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->