### PR TITLE
Server throws while authenticating with Twitch

### DIFF
--- a/server/src/auth/spotify.ts
+++ b/server/src/auth/spotify.ts
@@ -247,7 +247,7 @@ export const spotifyAuthCodeRouter = async () => {
       })
       .listen(port);
 
-    logger.info(`Spotify: Getting Auth Code with scopes ${pc.green(`${Config.twitch.scopes.join(', ')}`)}`);
+    logger.info(`Spotify: Getting Auth Code with scopes ${pc.green(`${Config.spotify.scopes.join(', ')}`)}`);
     await getSpotifyAuthCode();
   }
 };

--- a/server/src/auth/spotify.ts
+++ b/server/src/auth/spotify.ts
@@ -224,6 +224,14 @@ export const spotifyAuthCodeRouter = async () => {
   if (Config.spotify.client_id && !Config.spotify.auth_code) {
     const port = parseInt(Config.spotify.redirect_uri.split(':')[2]);
 
+    if (!Config.spotify.redirect_uri.includes("localhost")) {
+      throw new Error("Spotify: Only localhost is supported for auth redirect uri.");
+    }
+
+    if (Number.isNaN(port)) {
+      throw new Error("Spotify: Unable to get localhost port number for auth redirect route.");
+    }
+
     logger.info(`Listening on port ${String(port)} for Spotify auth code`);
 
     express()

--- a/server/src/auth/spotify.ts
+++ b/server/src/auth/spotify.ts
@@ -222,6 +222,10 @@ export const getSpotifyAccessToken = async (): Promise<void> => {
 
 export const spotifyAuthCodeRouter = async () => {
   if (Config.spotify.client_id && !Config.spotify.auth_code) {
+    const port = parseInt(Config.spotify.redirect_uri.split(':')[2]);
+
+    logger.info(`Listening on port ${String(port)} for Spotify auth code`);
+
     express()
       .get('/', (req, res) => {
         if (req.query.code) {
@@ -241,7 +245,7 @@ export const spotifyAuthCodeRouter = async () => {
           res.send('Hello from twitch-bot! No Spotify Auth Code received. You may close this window.');
         }
       })
-      .listen(3000);
+      .listen(port);
 
     logger.info(`Spotify: Getting Auth Code with scopes ${pc.green(`${Config.twitch.scopes.join(', ')}`)}`);
     await getSpotifyAuthCode();

--- a/server/src/auth/spotify.ts
+++ b/server/src/auth/spotify.ts
@@ -221,7 +221,7 @@ export const getSpotifyAccessToken = async (): Promise<void> => {
 };
 
 export const spotifyAuthCodeRouter = async () => {
-  if (Config.spotify.enabled && Config.spotify.client_id && !Config.spotify.auth_code) {
+  if (Config.spotify.client_id && !Config.spotify.auth_code) {
     express()
       .get('/', (req, res) => {
         if (req.query.code) {

--- a/server/src/auth/spotify.ts
+++ b/server/src/auth/spotify.ts
@@ -221,7 +221,7 @@ export const getSpotifyAccessToken = async (): Promise<void> => {
 };
 
 export const spotifyAuthCodeRouter = async () => {
-  if (Config.spotify.client_id && !Config.spotify.auth_code) {
+  if (Config.spotify.enabled && Config.spotify.client_id && !Config.spotify.auth_code) {
     express()
       .get('/', (req, res) => {
         if (req.query.code) {

--- a/server/src/auth/twitch.ts
+++ b/server/src/auth/twitch.ts
@@ -171,7 +171,7 @@ export const twitchAuthCodeRouter = async () => {
   if (Config.twitch.client_id && !Config.twitch.auth_code) {
     const port = parseInt(Config.twitch.redirect_uri.split(':')[2]);
 
-    if (!Config.spotify.redirect_uri.includes("localhost")) {
+    if (!Config.twitch.redirect_uri.includes("localhost")) {
       throw new Error("Twitch: Only localhost is supported for auth redirect uri.");
     }
 

--- a/server/src/auth/twitch.ts
+++ b/server/src/auth/twitch.ts
@@ -171,6 +171,14 @@ export const twitchAuthCodeRouter = async () => {
   if (Config.twitch.client_id && !Config.twitch.auth_code) {
     const port = parseInt(Config.twitch.redirect_uri.split(':')[2]);
 
+    if (!Config.spotify.redirect_uri.includes("localhost")) {
+      throw new Error("Twitch: Only localhost is supported for auth redirect uri.");
+    }
+
+    if (Number.isNaN(port)) {
+      throw new Error("Twitch: Unable to get localhost port number for auth redirect route.");
+    }
+
     logger.info(`Listening on port ${String(port)} for Twitch auth code`);
 
     express()

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,10 @@ async function main() {
     assertTokenFileExists();
 
     await twitchAuthCodeRouter();
-    await spotifyAuthCodeRouter();
+    
+    if (Config.spotify.enabled) {
+      await spotifyAuthCodeRouter();
+    }
 
     removeOldTTSFiles();
     loadBotCommands();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,10 +33,6 @@ async function main() {
     assertTokenFileExists();
 
     await twitchAuthCodeRouter();
-    
-    if (Config.spotify.enabled) {
-      await spotifyAuthCodeRouter();
-    }
 
     removeOldTTSFiles();
     loadBotCommands();
@@ -49,6 +45,8 @@ async function main() {
     await getTwitchAccessToken(Config.twitch);
 
     if (Config.spotify.enabled) {
+      await spotifyAuthCodeRouter();
+
       logger.info(`${pc.green('[Spotify enabled]')} Getting Spotify access token`);
       await getSpotifyAccessToken();
 


### PR DESCRIPTION
The server tries to authenticate with Spotify if you use the `example.config.json` file, despite the default to disable Spotify integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for Twitch authentication by validating the redirect URI and ensuring it uses localhost, preventing issues with incorrect configurations.

- **New Features**
  - Refined the Spotify integration to ensure the authentication process runs only when the feature is enabled in your settings.
  - Introduced a dynamic server listening port for the Spotify authentication, enhancing flexibility based on configuration settings.
  - Enhanced error handling for Twitch authentication by validating the redirect URI and ensuring the port number is valid before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->