### PR TITLE
Remove duplicate Zod parsing

### DIFF
--- a/server/src/handlers/bttv/fetchBetterTTVGlobalEmotes.ts
+++ b/server/src/handlers/bttv/fetchBetterTTVGlobalEmotes.ts
@@ -15,7 +15,7 @@ export const fetchBetterTTVGlobalEmotes = async (): Promise<BttvEmote[] | null> 
       const result = bttvEmotesSchema.safeParse(json);
       if (result.success) {
         logger.info(`Fetched BetterTTV global emotes`);
-        return bttvEmotesSchema.parse(json);
+        return result.data;
       } else {
         logger.error(`JSON response from BetterTTV API is not valid. Error: ${result.error.message}`);
         return json as BttvEmote[];

--- a/server/src/handlers/bttv/fetchBetterTTVUser.ts
+++ b/server/src/handlers/bttv/fetchBetterTTVUser.ts
@@ -14,7 +14,7 @@ export const fetchBetterTTVUser = async (): Promise<BttvUser | null> => {
       const result = bttvUserSchema.safeParse(json);
       if (result.success) {
         logger.info(`Fetched BetterTTV user`);
-        return bttvUserSchema.parse(json);
+        return result.data;
       } else {
         logger.error(`JSON response from BetterTTV API is not valid. Error: ${result.error.message}`);
         return json as BttvUser;

--- a/server/src/handlers/frankerfacez/fetchFrankerFaceZGlobalEmotes.ts
+++ b/server/src/handlers/frankerfacez/fetchFrankerFaceZGlobalEmotes.ts
@@ -14,7 +14,7 @@ export const fetchFrankerFaceZGlobalEmotes = async (): Promise<FrankerFaceZGloba
       const result = frankerFaceZGlobalEmotesSchema.safeParse(json);
       if (result.success) {
         logger.info(`Fetched FrankerFaceZ global emotes`);
-        return frankerFaceZGlobalEmotesSchema.parse(json);
+        return result.data;
       } else {
         logger.error(`JSON response from FrankerFaceZ API (fetchFrankerFaceZGlobalEmotes) is not valid. Error: ${result.error.message}`);
         return json as FrankerFaceZGlobalEmotes;

--- a/server/src/handlers/frankerfacez/fetchFrankerFaceZRoomEmotes.ts
+++ b/server/src/handlers/frankerfacez/fetchFrankerFaceZRoomEmotes.ts
@@ -14,7 +14,7 @@ export const fetchFrankerFaceZRoomEmotes = async (): Promise<FrankerFaceZRoomEmo
       const result = frankerFaceZRoomEmotesSchema.safeParse(json);
       if (result.success) {
         logger.info(`Fetched FrankerFaceZ room emotes`);
-        return result.data; 
+        return result.data;
       } else {
         logger.error(`JSON response from FrankerFaceZ API (fetchFrankerFaceZRoomEmotes) is not valid. Error: ${result.error.message}`);
         return json as FrankerFaceZRoomEmotes;

--- a/server/src/handlers/frankerfacez/fetchFrankerFaceZRoomEmotes.ts
+++ b/server/src/handlers/frankerfacez/fetchFrankerFaceZRoomEmotes.ts
@@ -14,7 +14,7 @@ export const fetchFrankerFaceZRoomEmotes = async (): Promise<FrankerFaceZRoomEmo
       const result = frankerFaceZRoomEmotesSchema.safeParse(json);
       if (result.success) {
         logger.info(`Fetched FrankerFaceZ room emotes`);
-        return frankerFaceZRoomEmotesSchema.parse(json);
+        return result.data; 
       } else {
         logger.error(`JSON response from FrankerFaceZ API (fetchFrankerFaceZRoomEmotes) is not valid. Error: ${result.error.message}`);
         return json as FrankerFaceZRoomEmotes;

--- a/server/src/handlers/sevenTV/fetchSevenTVEmote.ts
+++ b/server/src/handlers/sevenTV/fetchSevenTVEmote.ts
@@ -12,7 +12,7 @@ export const fetchSevenTVEmote = async (emoteId: string): Promise<SevenTVEmoteDa
     const result = sevenTVEmoteDataSchema.safeParse(json);
     if (result.success) {
       logger.info(`Fetched 7TV emote ${emoteId}`);
-      return sevenTVEmoteDataSchema.parse(json);
+      return result.data;
     } else {
       logger.error(`JSON response from 7TV API (fetchSevenTVEmote) is not valid. Error: ${result.error.message}`);
       return json as SevenTVEmoteData;

--- a/server/src/handlers/sevenTV/fetchSevenTVEmoteSets.ts
+++ b/server/src/handlers/sevenTV/fetchSevenTVEmoteSets.ts
@@ -12,7 +12,7 @@ export const fetchSevenTVEmoteSet = async (emoteSetId: string): Promise<SevenTVE
     const result = sevenTVEmoteSetSchema.safeParse(json);
     if (result.success) {
       logger.info(`Fetched 7TV emote set ${emoteSetId}`);
-      return sevenTVEmoteSetSchema.parse(json);
+      return result.data; 
     } else {
       logger.error(`JSON response from 7TV API (fetchSevenTVEmoteSet) is not valid. Error: ${result.error.message}`);
       return json as SevenTVEmoteSet;

--- a/server/src/handlers/sevenTV/fetchSevenTVEmoteSets.ts
+++ b/server/src/handlers/sevenTV/fetchSevenTVEmoteSets.ts
@@ -12,7 +12,7 @@ export const fetchSevenTVEmoteSet = async (emoteSetId: string): Promise<SevenTVE
     const result = sevenTVEmoteSetSchema.safeParse(json);
     if (result.success) {
       logger.info(`Fetched 7TV emote set ${emoteSetId}`);
-      return result.data; 
+      return result.data;
     } else {
       logger.error(`JSON response from 7TV API (fetchSevenTVEmoteSet) is not valid. Error: ${result.error.message}`);
       return json as SevenTVEmoteSet;

--- a/server/src/handlers/sevenTV/fetchSevenTVTwitchUser.ts
+++ b/server/src/handlers/sevenTV/fetchSevenTVTwitchUser.ts
@@ -14,7 +14,7 @@ export const fetchSevenTVTwitchUser = async (): Promise<SevenTVTwitchUser | null
       const result = sevenTVTwitchUserSchema.safeParse(json);
       if (result.success) {
         logger.info(`Fetched 7TV Twitch user`);
-        return sevenTVTwitchUserSchema.parse(json);
+        return result.data;
       } else {
         logger.error(`JSON response from 7TV API (fetchSevenTVTwitchUser) is not valid. Error: ${result.error.message}`);
         return json as SevenTVTwitchUser;


### PR DESCRIPTION
Hopefully I'm not misunderstanding how Zod works. But it seems to me that we're doing the parsing and type-checking work twice?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced response handling for external emote integrations. Third-party APIs now deliver directly validated and parsed data for global and channel emotes from BetterTTV, FrankerFaceZ, and SevenTV, ensuring a more consistent and streamlined experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->