### PR TITLE
Correct FrankerFaceZ emote modifier flags

### DIFF
--- a/client/src/views/Chat/parseFrankerFaceZModifierFlags.test.ts
+++ b/client/src/views/Chat/parseFrankerFaceZModifierFlags.test.ts
@@ -9,6 +9,8 @@ describe('parseFrankerFaceZModifierFlags', async () => {
   test('should return an array of flags', async () => {
     expect(parseFrankerFaceZModifierFlags(1)).toEqual(['hidden']);
     expect(parseFrankerFaceZModifierFlags(2048)).toEqual(['rainbow']);
-    expect(parseFrankerFaceZModifierFlags(65606)).toEqual(['bounce', 'growx', 'flipx', 'flipy', 'hidden']);
+    expect(parseFrankerFaceZModifierFlags(12_289)).toEqual(['hypershake', 'hyperred', 'hidden']);
+    // FIXME: This is incorrect?
+    // expect(parseFrankerFaceZModifierFlags(65_606)).toEqual(['bounce', 'growx', 'flipx', 'flipy', 'hidden']);
   });
 });

--- a/client/src/views/Chat/parseFrankerFaceZModifierFlags.test.ts
+++ b/client/src/views/Chat/parseFrankerFaceZModifierFlags.test.ts
@@ -10,7 +10,6 @@ describe('parseFrankerFaceZModifierFlags', async () => {
     expect(parseFrankerFaceZModifierFlags(1)).toEqual(['hidden']);
     expect(parseFrankerFaceZModifierFlags(2048)).toEqual(['rainbow']);
     expect(parseFrankerFaceZModifierFlags(12_289)).toEqual(['hypershake', 'hyperred', 'hidden']);
-    // FIXME: This is incorrect?
-    // expect(parseFrankerFaceZModifierFlags(65_606)).toEqual(['bounce', 'growx', 'flipx', 'flipy', 'hidden']);
+    expect(parseFrankerFaceZModifierFlags(65_606)).toEqual(['bounce', 'leave', 'flipy', 'flipx']);
   });
 });

--- a/client/src/views/Chat/parseFrankerFaceZModifierFlags.ts
+++ b/client/src/views/Chat/parseFrankerFaceZModifierFlags.ts
@@ -5,16 +5,18 @@ const FrankerFaceZModifierFlag = {
   growx: 8,
   slide: 16,
   appear: 32,
-  rotate: 64,
-  rotate90: 128,
-  greyscale: 256,
-  sepia: 512,
+  leave: 64,
+  rotate: 128,
+  rotate90: 256,
+  greyscale: 512,
+  sepia: 1024,
   rainbow: 2048,
   hyperred: 4096,
-  shake: 8192,
+  hypershake: 8192,
   cursed: 16384,
   jam: 32768,
   bounce: 65536,
+  nospace: 131072,
 };
 
 export function parseFrankerFaceZModifierFlags(flags: number): string[] {


### PR DESCRIPTION
When I ran the tests for the client I noticed it was failing the FFZ emote flag test. I noticed that the values for the emote modifier flags where shifted and a couple flags were missing, however this doesn't fix the failing test.

Used this as a reference: https://github.com/FrankerFaceZ/FrankerFaceZ/blob/872b0ff7313919287890ecc97096022603bbf836/src/modules/chat/emotes.js#L21, the `make_enum_flags()` function calculates the value to `2^index`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced chat visual modifiers for a more consistent and predictable display.
  - Refined several effect options and introduced an additional visual modifier to improve the overall chat experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->