### PR TITLE
Show username for localized display names

### DIFF
--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -86,6 +86,7 @@ export type ChatMessage = {
   id: string;
   user: {
     userId: string;
+    nick: string;
     displayName: string;
     welcomeMessage?: string;
     points: number;

--- a/client/src/views/Chat/Chat.less
+++ b/client/src/views/Chat/Chat.less
@@ -83,7 +83,6 @@
       padding-right: 0.2em;
       overflow: visible;
       white-space: nowrap;
-      text-overflow: ellipsis;
       display: inline-block;
     }
 
@@ -92,7 +91,6 @@
       padding-right: 0.2em;
       overflow: visible;
       white-space: nowrap;
-      text-overflow: ellipsis;
       display: inline-block;
     }
 

--- a/client/src/views/Chat/Chat.less
+++ b/client/src/views/Chat/Chat.less
@@ -78,8 +78,17 @@
       }
     }
 
-    &-nick {
+    &-displayname {
       font-weight: 700;
+      padding-right: 0.2em;
+      overflow: visible;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      display: inline-block;
+    }
+
+    &-nick {
+      font-weight: 400;
       padding-right: 0.2em;
       overflow: visible;
       white-space: nowrap;

--- a/client/src/views/Chat/ChatEntry.tsx
+++ b/client/src/views/Chat/ChatEntry.tsx
@@ -48,10 +48,12 @@ export const ChatEntry = ({
   // Set default user if no user
   const user = chatMessage.user ?? {
     displayName: chatMessage.parsedMessage.tags['display-name'] || 'unknown',
+    nick: 'unknown',
     avatarUrl: '',
   };
 
   const isSelected = selectedDisplayName === user.displayName;
+  const isLocalized = user.displayName.toLocaleLowerCase() !== user.nick;
 
   return (
     <button className={classNames('chat-message')} onClick={() => socket.current?.emit('setSelectedDisplayName', user.displayName)}>
@@ -82,13 +84,23 @@ export const ChatEntry = ({
           {showAvatars && user.avatarUrl && <img className="chat-message-avatar-image" src={user.avatarUrl} alt="avatar" height={34} />}
           <UserBadges badges={chatMessage.parsedMessage.tags.badges} />
           <span
-            className="chat-message-nick"
+            className="chat-message-displayname"
             style={{
               color: isSelected || chatMessage.isSpotlighted ? 'white' : contrastCorrected(color || '#fff', backgroundColor),
             }}
           >
             {user.displayName}
           </span>
+          {isLocalized && (
+            <span
+              className="chat-message-nick"
+              style={{
+                color: isSelected || chatMessage.isSpotlighted ? 'white' : contrastCorrected(color || '#fff', backgroundColor),
+              }}
+            >
+              (@{user.nick})
+            </span>
+          )}
           {showColonAfterDisplayName && !actionMessage && ': '}
           <span className={classNames('chat-message-text', actionMessage && 'chat-message-text-action')}>
             <ChatImageRenderer

--- a/client/src/views/Dashboard/ChatPreview.tsx
+++ b/client/src/views/Dashboard/ChatPreview.tsx
@@ -27,6 +27,7 @@ export const ChatPreview = () => {
       lastSeen: '2023-07-03T17:43:21.776Z',
       avatarUrl: 'https://static-cdn.jtvnw.net/jtv_user_pictures/6e159f50-bab1-4e19-90e6-10c09710b2dc-profile_image-300x300.png',
       displayName: 'Athano',
+      nick: 'athano',
     },
     parsedMessage: {
       tags: {
@@ -103,7 +104,8 @@ export const ChatPreview = () => {
             },
           },
           user: {
-            displayName: 'OtherUser',
+            displayName: 'ねこ',
+            nick: 'cat',
             avatarUrl: 'https://picsum.photos/100/100',
             experience: 0,
             points: 0,


### PR DESCRIPTION
If a user has a localized display name (written in Chinese, Korean or Japanese) then their English username is shown alongside the display name.

Closes https://github.com/mjfwebb/twitch-bot/issues/676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Chat messages now support an additional nickname attribute that appears alongside the primary name when they differ, enhancing personalization.
  - User objects in chat previews now include nicknames for improved identification.

- **Style**
  - Refined the appearance of chat entries to clearly distinguish between the official display name and the alternative nickname for a more intuitive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->